### PR TITLE
Feature/code refactoring

### DIFF
--- a/src/board/piece.rs
+++ b/src/board/piece.rs
@@ -1,16 +1,9 @@
 //! Module containing chess piece related logic and structures.
-use crate::board::moves::Move;
-use crate::board::Board;
-
-use self::king::generate_king_moves;
-use self::knight::generate_knight_moves;
-use self::pawn::generate_pawn_moves;
-use self::sliding_pieces::generate_sliding_moves;
 
 pub mod king;
 pub mod knight;
 pub mod pawn;
-mod sliding_pieces;
+pub mod sliding_pieces;
 
 /// Represents a chess piece, containing its type and color.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -34,17 +27,6 @@ impl Piece {
             (PieceType::Queen, Color::Black) => 'q',
             (PieceType::King, Color::White) => 'K',
             (PieceType::King, Color::Black) => 'k',
-        }
-    }
-
-    pub fn generate_moves(&self, board: &Board, row: u8, col: u8) -> Option<Vec<Move>> {
-        match self.piece_type {
-            PieceType::Pawn => generate_pawn_moves(board, row, col, self.color),
-            PieceType::Bishop => generate_sliding_moves(*self, board, row, col),
-            PieceType::Knight => generate_knight_moves(board, row, col),
-            PieceType::Rook => generate_sliding_moves(*self, board, row, col),
-            PieceType::Queen => generate_sliding_moves(*self, board, row, col),
-            PieceType::King => generate_king_moves(board, row, col),
         }
     }
 }

--- a/src/board/piece/king.rs
+++ b/src/board/piece/king.rs
@@ -59,6 +59,7 @@ mod king_tests {
         let row = 3;
         let col = 3;
         let square = row * BOARD_SIZE + col;
+        let current_player = Color::White;
 
         let king = Piece {
             piece_type: PieceType::King,
@@ -66,7 +67,7 @@ mod king_tests {
         };
         board.set_piece(square, king);
 
-        let moves = king.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         let expected_moves = vec![
             Move {
@@ -113,14 +114,15 @@ mod king_tests {
         let row = 0;
         let col = 0;
         let square = row * BOARD_SIZE + col;
+        let current_player = Color::White;
 
         let king = Piece {
             piece_type: PieceType::King,
-            color: Color::Black,
+            color: Color::White,
         };
         board.set_piece(square, king);
 
-        let moves = king.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         let expected_moves = vec![
             Move {
@@ -147,6 +149,7 @@ mod king_tests {
         let row = 2;
         let col = 7;
         let square = row * BOARD_SIZE + col;
+        let current_player = Color::White;
 
         let king = Piece {
             piece_type: PieceType::King,
@@ -154,7 +157,7 @@ mod king_tests {
         };
         board.set_piece(square, king);
 
-        let moves = king.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         let expected_moves = vec![
             Move {

--- a/src/board/piece/king.rs
+++ b/src/board/piece/king.rs
@@ -37,11 +37,67 @@ pub fn generate_king_moves(board: &Board, row: u8, col: u8) -> Option<Vec<Move>>
             }
         }
     }
+    generate_white_castling_moves(square, board, &mut moves);
+    generate_black_castling_moves(square, board, &mut moves);
 
     if !moves.is_empty() {
         Some(moves)
     } else {
         None
+    }
+}
+
+fn generate_black_castling_moves(square: u8, board: &Board, moves: &mut Vec<Move>) {
+    // checking for black castling
+    // king original position
+    if square == 60 {
+        // king side
+        if board.castling_availability.2
+            && board.get_piece(61).is_none()
+            && board.get_piece(62).is_none()
+        {
+            moves.push(Move {
+                initial_square: square,
+                target_square: 62,
+            });
+        }
+        // queen side
+        if board.castling_availability.3
+            && board.get_piece(59).is_none()
+            && board.get_piece(58).is_none()
+        {
+            moves.push(Move {
+                initial_square: square,
+                target_square: 58,
+            });
+        }
+    }
+}
+
+fn generate_white_castling_moves(square: u8, board: &Board, moves: &mut Vec<Move>) {
+    // checking for white castling
+    // king original position
+    if square == 4 {
+        // king side
+        if board.castling_availability.0
+            && board.get_piece(5).is_none()
+            && board.get_piece(6).is_none()
+        {
+            moves.push(Move {
+                initial_square: square,
+                target_square: 6,
+            });
+        }
+        // queen side
+        if board.castling_availability.1
+            && board.get_piece(3).is_none()
+            && board.get_piece(2).is_none()
+        {
+            moves.push(Move {
+                initial_square: square,
+                target_square: 2,
+            });
+        }
     }
 }
 
@@ -56,16 +112,14 @@ mod king_tests {
     #[test]
     fn test_generate_king_moves_middle() {
         let mut board = Board::new_empty_board();
-        let row = 3;
-        let col = 3;
-        let square = row * BOARD_SIZE + col;
+        let white_king_square = 27;
         let current_player = Color::White;
 
-        let king = Piece {
+        let white_king = Piece {
             piece_type: PieceType::King,
             color: Color::White,
         };
-        board.set_piece(square, king);
+        board.set_piece(white_king_square, white_king);
 
         let moves = board.generate_moves(current_player);
 
@@ -111,16 +165,14 @@ mod king_tests {
     #[test]
     fn test_generate_king_moves_corner() {
         let mut board = Board::new_empty_board();
-        let row = 0;
-        let col = 0;
-        let square = row * BOARD_SIZE + col;
         let current_player = Color::White;
+        let white_king_square = 0;
 
-        let king = Piece {
+        let white_king = Piece {
             piece_type: PieceType::King,
             color: Color::White,
         };
-        board.set_piece(square, king);
+        board.set_piece(white_king_square, white_king);
 
         let moves = board.generate_moves(current_player);
 
@@ -146,16 +198,14 @@ mod king_tests {
     #[test]
     fn test_generate_king_moves_side() {
         let mut board = Board::new_empty_board();
-        let row = 2;
-        let col = 7;
-        let square = row * BOARD_SIZE + col;
         let current_player = Color::White;
+        let white_king_square = 23;
 
-        let king = Piece {
+        let white_king = Piece {
             piece_type: PieceType::King,
             color: Color::White,
         };
-        board.set_piece(square, king);
+        board.set_piece(white_king_square, white_king);
 
         let moves = board.generate_moves(current_player);
 
@@ -179,6 +229,290 @@ mod king_tests {
             Move {
                 initial_square: 23,
                 target_square: 31,
+            },
+        ];
+
+        assert_eq!(moves.len(), expected_moves.len());
+        assert!(are_moves_equal(&moves, &expected_moves));
+    }
+
+    #[test]
+    fn test_white_king_castling_both_sides() {
+        let mut board = Board::new_empty_board();
+        let current_player = Color::White;
+        let white_king_square = 4;
+
+        let white_king = Piece {
+            piece_type: PieceType::King,
+            color: Color::White,
+        };
+        board.set_piece(white_king_square, white_king);
+        board.castling_availability = (true, true, false, false);
+
+        let moves = board.generate_moves(current_player);
+
+        let expected_moves = vec![
+            Move {
+                initial_square: 4,
+                target_square: 3,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 11,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 12,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 13,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 5,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 2,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 6,
+            },
+        ];
+
+        assert_eq!(moves.len(), expected_moves.len());
+        assert!(are_moves_equal(&moves, &expected_moves));
+    }
+
+    #[test]
+    fn test_white_king_castling_queen_side() {
+        let mut board = Board::new_empty_board();
+        let current_player = Color::White;
+        let white_king_square = 4;
+
+        let white_king = Piece {
+            piece_type: PieceType::King,
+            color: Color::White,
+        };
+        board.set_piece(white_king_square, white_king);
+        board.castling_availability = (false, true, false, false);
+
+        let moves = board.generate_moves(current_player);
+
+        let expected_moves = vec![
+            Move {
+                initial_square: 4,
+                target_square: 3,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 11,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 12,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 13,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 5,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 2,
+            },
+        ];
+
+        assert_eq!(moves.len(), expected_moves.len());
+        assert!(are_moves_equal(&moves, &expected_moves));
+    }
+
+    #[test]
+    fn test_white_king_castling_king_side() {
+        let mut board = Board::new_empty_board();
+        let current_player = Color::White;
+        let white_king_square = 4;
+
+        let white_king = Piece {
+            piece_type: PieceType::King,
+            color: Color::White,
+        };
+        board.set_piece(white_king_square, white_king);
+        board.castling_availability = (true, false, false, false);
+
+        let moves = board.generate_moves(current_player);
+
+        let expected_moves = vec![
+            Move {
+                initial_square: 4,
+                target_square: 3,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 11,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 12,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 13,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 5,
+            },
+            Move {
+                initial_square: 4,
+                target_square: 6,
+            },
+        ];
+
+        assert_eq!(moves.len(), expected_moves.len());
+        assert!(are_moves_equal(&moves, &expected_moves));
+    }
+
+    #[test]
+    fn test_black_king_castling_both_sides() {
+        let mut board = Board::new_empty_board();
+        let current_player = Color::Black;
+        let white_king_square = 60;
+
+        let white_king = Piece {
+            piece_type: PieceType::King,
+            color: Color::Black,
+        };
+        board.set_piece(white_king_square, white_king);
+        board.castling_availability = (false, false, true, true);
+
+        let moves = board.generate_moves(current_player);
+
+        let expected_moves = vec![
+            Move {
+                initial_square: 60,
+                target_square: 59,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 61,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 51,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 52,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 53,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 62,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 58,
+            },
+        ];
+
+        assert_eq!(moves.len(), expected_moves.len());
+        assert!(are_moves_equal(&moves, &expected_moves));
+    }
+
+    #[test]
+    fn test_black_king_castling_queen_side() {
+        let mut board = Board::new_empty_board();
+        let current_player = Color::Black;
+        let white_king_square = 60;
+
+        let white_king = Piece {
+            piece_type: PieceType::King,
+            color: Color::Black,
+        };
+        board.set_piece(white_king_square, white_king);
+        board.castling_availability = (false, false, false, true);
+
+        let moves = board.generate_moves(current_player);
+
+        let expected_moves = vec![
+            Move {
+                initial_square: 60,
+                target_square: 59,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 61,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 51,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 52,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 53,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 58,
+            },
+        ];
+
+        assert_eq!(moves.len(), expected_moves.len());
+        assert!(are_moves_equal(&moves, &expected_moves));
+    }
+
+    #[test]
+    fn test_black_king_castling_king_side() {
+        let mut board = Board::new_empty_board();
+        let current_player = Color::Black;
+        let white_king_square = 60;
+
+        let white_king = Piece {
+            piece_type: PieceType::King,
+            color: Color::Black,
+        };
+        board.set_piece(white_king_square, white_king);
+        board.castling_availability = (false, false, true, false);
+
+        let moves = board.generate_moves(current_player);
+
+        let expected_moves = vec![
+            Move {
+                initial_square: 60,
+                target_square: 59,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 61,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 51,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 52,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 53,
+            },
+            Move {
+                initial_square: 60,
+                target_square: 62,
             },
         ];
 

--- a/src/board/piece/knight.rs
+++ b/src/board/piece/knight.rs
@@ -197,17 +197,16 @@ mod tests {
     #[test]
     fn test_generate_knight_moves_middle() {
         let mut board = Board::new_empty_board();
-        let row = 3;
-        let col = 3;
-        let square = row * BOARD_SIZE + col;
+        let current_player = Color::White;
+        let white_knight_square = 27;
 
-        let knight = Piece {
+        let white_knight = Piece {
             piece_type: PieceType::Knight,
             color: Color::White,
         };
-        board.set_piece(square, knight);
+        board.set_piece(white_knight_square, white_knight);
 
-        let moves = knight.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         let expected_moves = vec![
             Move {
@@ -251,17 +250,16 @@ mod tests {
     #[test]
     fn test_generate_knight_moves_corner() {
         let mut board = Board::new_empty_board();
-        let row = 0;
-        let col = 0;
-        let square = row * BOARD_SIZE + col;
+        let current_player = Color::White;
+        let white_knight_square = 0;
 
-        let knight = Piece {
+        let white_knight = Piece {
             piece_type: PieceType::Knight,
-            color: Color::Black,
+            color: Color::White,
         };
-        board.set_piece(square, knight);
+        board.set_piece(white_knight_square, white_knight);
 
-        let moves = knight.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         let expected_moves = vec![
             Move {
@@ -281,17 +279,15 @@ mod tests {
     #[test]
     fn test_generate_knight_moves_side() {
         let mut board = Board::new_empty_board();
-        let row = 2;
-        let col = 7;
-        let square = row * BOARD_SIZE + col;
-
-        let knight = Piece {
+        let current_player = Color::White;
+        let white_knight_square = 23;
+        let white_knight = Piece {
             piece_type: PieceType::Knight,
             color: Color::White,
         };
-        board.set_piece(square, knight);
+        board.set_piece(white_knight_square, white_knight);
 
-        let moves = knight.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         let expected_moves = vec![
             Move {

--- a/src/board/piece/pawn.rs
+++ b/src/board/piece/pawn.rs
@@ -207,15 +207,14 @@ mod tests {
     #[test]
     fn test_generate_pawn_moves_white() {
         let mut board = Board::new_empty_board();
-        let row = 1;
-        let col = 3;
-        let square = row * BOARD_SIZE + col;
-        let pawn = Piece {
+        let current_player = Color::White;
+        let white_pawn_square = 11;
+        let white_pawn = Piece {
             piece_type: Pawn,
             color: White,
         };
-        board.set_piece(square, pawn);
-        let moves = pawn.generate_moves(&board, row, col).unwrap();
+        board.set_piece(white_pawn_square, white_pawn);
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 2);
 
@@ -235,15 +234,14 @@ mod tests {
     #[test]
     fn test_generate_pawn_moves_black() {
         let mut board = Board::new_empty_board();
-        let row = 6;
-        let col = 3;
-        let square = row * BOARD_SIZE + col;
-        let pawn = Piece {
+        let current_player = Color::Black;
+        let black_pawn_square = 51;
+        let black_pawn = Piece {
             piece_type: Pawn,
             color: Black,
         };
-        board.set_piece(square, pawn);
-        let moves = pawn.generate_moves(&board, row, col).unwrap();
+        board.set_piece(black_pawn_square, black_pawn);
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 2);
 
@@ -263,11 +261,9 @@ mod tests {
     #[test]
     fn test_generate_pawn_moves_white_only_one_square_move_allowed() {
         let mut board = Board::new_empty_board();
-        let row = 1;
-        let col = 3;
-
-        let white_pawn_square = row * BOARD_SIZE + col;
-        let black_pawn_square = (row + 2) * BOARD_SIZE + col;
+        let current_player = Color::White;
+        let white_pawn_square = 11;
+        let black_pawn_square = 27;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -281,7 +277,7 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = white_pawn.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 1);
 
@@ -301,11 +297,9 @@ mod tests {
     #[test]
     fn test_generate_pawn_move_black_only_one_square_allowed() {
         let mut board = Board::new_empty_board();
-        let row = 6;
-        let col = 3;
-
-        let white_pawn_square = (row - 2) * BOARD_SIZE + col;
-        let black_pawn_square = row * BOARD_SIZE + col;
+        let current_player = Color::Black;
+        let white_pawn_square = 35;
+        let black_pawn_square = 51;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -319,7 +313,7 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = black_pawn.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 1);
 
@@ -339,11 +333,9 @@ mod tests {
     #[test]
     fn test_generate_pawn_move_white_takes_piece_from_starting_row() {
         let mut board = Board::new_empty_board();
-        let row = 1;
-        let col = 3;
-
-        let white_pawn_square = row * BOARD_SIZE + col;
-        let black_pawn_square = (row + 1) * BOARD_SIZE + col + 1;
+        let current_player = Color::White;
+        let white_pawn_square = 11;
+        let black_pawn_square = 20;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -357,7 +349,7 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = white_pawn.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 3);
 
@@ -383,11 +375,9 @@ mod tests {
     #[test]
     fn test_generate_pawn_move_white_takes_piece() {
         let mut board = Board::new_empty_board();
-        let row = 3;
-        let col = 3;
-
-        let white_pawn_square = row * BOARD_SIZE + col;
-        let black_pawn_square = (row + 1) * BOARD_SIZE + col + 1;
+        let current_player = Color::White;
+        let white_pawn_square = 27;
+        let black_pawn_square = 36;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -401,7 +391,7 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = white_pawn.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 2);
 
@@ -421,11 +411,9 @@ mod tests {
     #[test]
     fn test_generate_pawn_move_black_takes_piece_from_starting_row() {
         let mut board = Board::new_empty_board();
-        let row = 6;
-        let col = 3;
-
-        let white_pawn_square = (row - 1) * BOARD_SIZE + col + 1;
-        let black_pawn_square = row * BOARD_SIZE + col;
+        let current_player = Color::Black;
+        let white_pawn_square = 44;
+        let black_pawn_square = 51;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -438,8 +426,7 @@ mod tests {
 
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
-
-        let moves = black_pawn.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 3);
 
@@ -465,11 +452,10 @@ mod tests {
     #[test]
     fn test_generate_pawn_move_black_takes_piece() {
         let mut board = Board::new_empty_board();
-        let row = 4;
-        let col = 3;
+        let current_player = Color::Black;
 
-        let white_pawn_square = (row - 1) * BOARD_SIZE + col - 1;
-        let black_pawn_square = row * BOARD_SIZE + col;
+        let white_pawn_square = 26;
+        let black_pawn_square = 35;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -483,7 +469,7 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = black_pawn.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 2);
 
@@ -503,11 +489,9 @@ mod tests {
     #[test]
     fn test_generate_pawn_move_white_on_first_col() {
         let mut board = Board::new_empty_board();
-        let row = 3;
-        let col = 0;
-
-        let white_pawn_square = row * BOARD_SIZE + col;
-        let black_pawn_square = (row + 1) * BOARD_SIZE + col + 1;
+        let current_player = Color::White;
+        let white_pawn_square = 24;
+        let black_pawn_square = 33;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -521,7 +505,7 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = white_pawn.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 2);
 
@@ -541,11 +525,9 @@ mod tests {
     #[test]
     fn test_generate_pawn_move_white_on_last_col() {
         let mut board = Board::new_empty_board();
-        let row = 3;
-        let col = 7;
-
-        let white_pawn_square = row * BOARD_SIZE + col;
-        let black_pawn_square = (row + 1) * BOARD_SIZE + col - 1;
+        let current_player = Color::White;
+        let white_pawn_square = 31;
+        let black_pawn_square = 38;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -559,7 +541,7 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = white_pawn.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 2);
 
@@ -579,11 +561,9 @@ mod tests {
     #[test]
     fn test_generate_pawn_move_black_on_first_col() {
         let mut board = Board::new_empty_board();
-        let row = 6;
-        let col = 0;
-
-        let white_pawn_square = (row - 1) * BOARD_SIZE + col + 1;
-        let black_pawn_square = row * BOARD_SIZE + col;
+        let white_pawn_square = 41;
+        let black_pawn_square = 48;
+        let current_player = Color::Black;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -597,7 +577,7 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = black_pawn.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 3);
 
@@ -623,11 +603,9 @@ mod tests {
     #[test]
     fn test_generate_pawn_move_black_on_last_col() {
         let mut board = Board::new_empty_board();
-        let row = 6;
-        let col = 7;
-
-        let white_pawn_square = (row - 1) * BOARD_SIZE + col - 1;
-        let black_pawn_square = row * BOARD_SIZE + col;
+        let current_player = Color::Black;
+        let white_pawn_square = 46;
+        let black_pawn_square = 55;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -641,7 +619,7 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = black_pawn.generate_moves(&board, row, col).unwrap();
+        let moves = board.generate_moves(current_player);
 
         assert_eq!(moves.len(), 3);
 
@@ -667,11 +645,9 @@ mod tests {
     #[test]
     fn test_generate_pawn_move_white_blocked() {
         let mut board = Board::new_empty_board();
-        let row = 3;
-        let col = 0;
-
-        let white_pawn_square = row * BOARD_SIZE + col;
-        let black_pawn_square = (row + 1) * BOARD_SIZE + col;
+        let current_player = Color::White;
+        let white_pawn_square = 24;
+        let black_pawn_square = 32;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -685,19 +661,18 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = white_pawn.generate_moves(&board, row, col);
+        let moves = board.generate_moves(current_player);
 
-        assert_eq!(moves, None);
+        assert_eq!(moves, vec![]);
     }
 
     #[test]
     fn test_generate_pawn_move_black_blocked() {
         let mut board = Board::new_empty_board();
-        let row = 6;
-        let col = 0;
+        let current_player = Color::Black;
 
-        let white_pawn_square = (row - 1) * BOARD_SIZE + col;
-        let black_pawn_square = row * BOARD_SIZE + col;
+        let white_pawn_square = 40;
+        let black_pawn_square = 48;
 
         let white_pawn = Piece {
             piece_type: Pawn,
@@ -711,8 +686,8 @@ mod tests {
         board.set_piece(white_pawn_square, white_pawn);
         board.set_piece(black_pawn_square, black_pawn);
 
-        let moves = black_pawn.generate_moves(&board, row, col);
+        let moves = board.generate_moves(current_player);
 
-        assert_eq!(moves, None);
+        assert_eq!(moves, vec![]);
     }
 }

--- a/src/board/piece/sliding_pieces.rs
+++ b/src/board/piece/sliding_pieces.rs
@@ -6,7 +6,7 @@ use super::{Color, Piece, PieceType};
 /// Expected pieces are `Bishop`, `Rook`, and `Queen`.
 /// Based on the piece type, this function will generate moves in the
 /// diagonal directions, linear directions, or both.
-pub fn generate_sliding_moves(piece: Piece, board: &Board, row: u8, col: u8) -> Option<Vec<Move>> {
+pub fn generate_sliding_moves(board: &Board, row: u8, col: u8, piece: Piece) -> Option<Vec<Move>> {
     let mut moves: Vec<Move> = Vec::new();
 
     match piece.piece_type {
@@ -858,7 +858,7 @@ mod piece_move_tests {
             piece_type: PieceType::Queen,
             color: Color::White,
         };
-        let moves = generate_sliding_moves(queen, &board, 3, 3);
+        let moves = generate_sliding_moves(&board, 3, 3, queen);
         assert!(moves.is_some());
         assert_eq!(moves.unwrap().len(), 27);
     }
@@ -877,7 +877,7 @@ mod piece_move_tests {
                 color: Color::White,
             },
         );
-        let moves = generate_sliding_moves(queen, &board, 3, 3);
+        let moves = generate_sliding_moves(&board, 3, 3, queen);
         assert!(moves.is_some());
         assert_eq!(moves.unwrap().len(), 24);
     }
@@ -903,7 +903,7 @@ mod piece_move_tests {
                 color: Color::Black,
             },
         );
-        let moves = generate_sliding_moves(queen, &board, 3, 3);
+        let moves = generate_sliding_moves(&board, 3, 3, queen);
         assert!(moves.is_some());
         assert_eq!(moves.unwrap().len(), 22);
     }
@@ -915,7 +915,7 @@ mod piece_move_tests {
             piece_type: PieceType::Rook,
             color: Color::White,
         };
-        let moves = generate_sliding_moves(rook, &board, 3, 3);
+        let moves = generate_sliding_moves(&board, 3, 3, rook);
         assert!(moves.is_some());
         assert_eq!(moves.unwrap().len(), 14);
     }
@@ -934,7 +934,7 @@ mod piece_move_tests {
                 color: Color::Black,
             },
         );
-        let moves = generate_sliding_moves(rook, &board, 3, 3);
+        let moves = generate_sliding_moves(&board, 3, 3, rook);
         assert!(moves.is_some());
         assert_eq!(moves.unwrap().len(), 12);
     }
@@ -960,7 +960,7 @@ mod piece_move_tests {
                 color: Color::White,
             },
         );
-        let moves = generate_sliding_moves(rook, &board, 3, 3);
+        let moves = generate_sliding_moves(&board, 3, 3, rook);
         assert!(moves.is_some());
         assert_eq!(moves.unwrap().len(), 9);
     }
@@ -972,7 +972,7 @@ mod piece_move_tests {
             piece_type: PieceType::Bishop,
             color: Color::White,
         };
-        let moves = generate_sliding_moves(bishop, &board, 3, 3);
+        let moves = generate_sliding_moves(&board, 3, 3, bishop);
         assert!(moves.is_some());
         assert_eq!(moves.unwrap().len(), 13);
     }
@@ -991,7 +991,7 @@ mod piece_move_tests {
                 color: Color::Black,
             },
         );
-        let moves = generate_sliding_moves(bishop, &board, 3, 3);
+        let moves = generate_sliding_moves(&board, 3, 3, bishop);
         assert!(moves.is_some());
         assert_eq!(moves.unwrap().len(), 10);
     }
@@ -1017,7 +1017,7 @@ mod piece_move_tests {
                 color: Color::White,
             },
         );
-        let moves = generate_sliding_moves(bishop, &board, 3, 3);
+        let moves = generate_sliding_moves(&board, 3, 3, bishop);
         assert!(moves.is_some());
         assert_eq!(moves.unwrap().len(), 8);
     }

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -72,7 +72,7 @@ impl FromStr for GameState {
         // Parse the FEN string
         let piece_placement = iter.next().expect("Invalid FEN: missing piece placement");
         let active_color = iter.next().expect("Invalid FEN: missing active color");
-        let _castling_availability = iter
+        let castling_availability = iter
             .next()
             .expect("Invalid FEN: missing castling availability");
         let _en_passant_target = iter.next().expect("Invalid FEN: missing en passant target");
@@ -98,8 +98,10 @@ impl FromStr for GameState {
             .parse()
             .expect("Invalid FEN: invalid full move number");
 
+        // castling availabilty
+        game_state.board.castling_availability = parse_castling_availablity(castling_availability);
+
         // TODO missing other rules:
-        // castling
         // en passant
         // half move clock
 
@@ -112,4 +114,55 @@ pub enum GameResult {
     BlackWon,
     Draw,
     Undecided,
+}
+
+/// Parses a castling availability string and returns a tuple representing castling availability.
+///
+/// The castling availability string is a sequence of characters representing the availability of
+/// castling for both white and black players. The characters used are:
+/// - 'K': King-side castling for white.
+/// - 'Q': Queen-side castling for white.
+/// - 'k': King-side castling for black.
+/// - 'q': Queen-side castling for black.
+///
+/// # Arguments
+///
+/// * `castling_availabilyt_str` - The castling availability string to parse.
+///
+/// # Returns
+///
+/// A tuple with four elements representing the castling availability:
+/// * Element 0: Availability of King-side castling for white.
+/// * Element 1: Availability of Queen-side castling for white.
+/// * Element 2: Availability of King-side castling for black.
+/// * Element 3: Availability of Queen-side castling for black.
+///
+/// # Examples
+///
+/// ```
+/// let castling_str = "KQkq";
+/// let castling_availability = parse_castling_availablity(castling_str);
+/// assert_eq!(castling_availability, (true, true, true, true));
+/// ```
+///
+/// ```
+/// let castling_str = "Kq";
+/// let castling_availability = parse_castling_availablity(castling_str);
+/// assert_eq!(castling_availability, (true, false, false, true));
+/// ```
+fn parse_castling_availablity(castling_availabilyt_str: &str) -> (bool, bool, bool, bool) {
+    let mut castling_availablity = (false, false, false, false);
+    if castling_availabilyt_str.contains('K') {
+        castling_availablity.0 = true;
+    }
+    if castling_availabilyt_str.contains('Q') {
+        castling_availablity.1 = true;
+    }
+    if castling_availabilyt_str.contains('k') {
+        castling_availablity.2 = true;
+    }
+    if castling_availabilyt_str.contains('q') {
+        castling_availablity.3 = true;
+    }
+    castling_availablity
 }


### PR DESCRIPTION
Refactored board and piece

- Generate moves removed from Piece.rs
- Board generates the moves directly from pieces like Piece.rs used to do
- Board has a tuple (bool, bool, bool, bool) field. this indicates castling availability for white-king-side, white-queen-side, black-king-side, black-queen-side
- Added castling moves
- Refactored all unit tests to not use row+col, and use 1D square index